### PR TITLE
Cope with Validate::Tiny API change from v1.501

### DIFF
--- a/lib/Dancer/Plugin/CRUD.pm
+++ b/lib/Dancer/Plugin/CRUD.pm
@@ -212,12 +212,25 @@ sub _generate_sub {
                     %{ params('body') },
                     %{ captures() || {} }
                 };
-                my $result = Validate::Tiny->new(
-                    $input,
-                    {
-                        %$rules, fields => [ @idfields, @{ $rules->{fields} } ]
-                    }
-                );
+                my $result;
+                if ( Validate::Tiny->can('check') ) {
+                    $result = Validate::Tiny->new()->check(
+                        $input,
+                        {
+                            %$rules,
+                            fields => [ @idfields, @{ $rules->{fields} } ]
+                        }
+                    );
+                }
+                else {
+                    $result = Validate::Tiny->new(
+                        $input,
+                        {
+                            %$rules,
+                            fields => [ @idfields, @{ $rules->{fields} } ]
+                        }
+                    );
+                }
                 unless ( $result->success ) {
                     status(400);
                     return { error => $result->error };


### PR DESCRIPTION
As per GH issue #2 Validate::Tiny changed its API as from v1.501:

> Object interface changed - new is now just a constructor and check is used
> to do actual validation. To adapt your code, it should be enough to just
> replace all Validate::Tiny->new with Validate::Tiny->check.

This commit checks whether `Validate::Tiny->can('check')` and calls constructor or constructor plus 'check' accordingly.
